### PR TITLE
Add type /types/index.d.ts with supertest type

### DIFF
--- a/nightwatch/types/index.d.ts
+++ b/nightwatch/types/index.d.ts
@@ -1,0 +1,9 @@
+import { SuperTest, Test } from 'supertest';
+
+declare module 'nightwatch' {
+  export interface NightwatchCustomCommands {
+    supertest: {
+      request: (app: any) => SuperTest<Test>;
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "0.2.1",
   "description": "",
   "main": "index.js",
+  "types": "./nightwatch/types/index.d.ts",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
This change _should_ allow typescript projects using this plugin in Nightwatch to add `"types": ["@nightwatch/apitesting"],` to their tsconfig.json to add the .supertest type to the Nightwatch API when writing their tests

```json
{
  "compilerOptions": {
    "types": ["@nightwatch/apitesting"],
  }
}
```

Traditionally, the type file is at the same level of index.js, but in some examples I've seen for Nightwatch plugins the types were under `/nightwatch/types/<typefilehere>` so that is why I went with that placement.