### PR TITLE
Type support - addendum

### DIFF
--- a/nightwatch/types/index.d.ts
+++ b/nightwatch/types/index.d.ts
@@ -1,0 +1,9 @@
+import { SuperTest, Test } from 'supertest';
+
+declare module 'nightwatch' {
+  export interface NightwatchCustomCommands {
+    supertest: {
+      request: (app: any) => SuperTest<Test>;
+    };
+  }
+}

--- a/nightwatch/types/index.d.ts
+++ b/nightwatch/types/index.d.ts
@@ -1,4 +1,5 @@
 import { SuperTest, Test } from 'supertest';
+export * from 'nightwatch';
 
 declare module 'nightwatch' {
   export interface NightwatchCustomCommands {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "0.2.1",
   "description": "",
   "main": "index.js",
+  "types": "./nightwatch/types/index.d.ts",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
I mistakenly took out a line exporting nightwatch `export * from 'nightwatch';` when I published the first PR. Without this you won't get the chained commands after `browser.supertest.request`
This PR should fix that.