### PR TITLE
Exports nightwatch in types to fix issue where only browser.supertest…

### DIFF
--- a/nightwatch/types/index.d.ts
+++ b/nightwatch/types/index.d.ts
@@ -1,4 +1,5 @@
 import { SuperTest, Test } from 'supertest';
+export * from 'nightwatch';
 
 declare module 'nightwatch' {
   export interface NightwatchCustomCommands {


### PR DESCRIPTION
I mistakenly took out a line exporting nightwatch export * from 'nightwatch'; when I published the first PR. Without this you won't get the chained commands after browser.supertest.request
This PR should fix that.